### PR TITLE
Increase threshold to 10

### DIFF
--- a/src/Microsoft.DotnetOrg.Policies/Rules/PR08_TooManyRepoAdmins.cs
+++ b/src/Microsoft.DotnetOrg.Policies/Rules/PR08_TooManyRepoAdmins.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotnetOrg.Policies.Rules
 
         public override IEnumerable<PolicyViolation> GetViolations(PolicyAnalysisContext context)
         {
-            const int Threshold = 4;
+            const int Threshold = 10;
 
             foreach (var repo in context.Org.Repos)
             {

--- a/src/Microsoft.DotnetOrg.Policies/Rules/PR09_TooManyTeamMaintainers.cs
+++ b/src/Microsoft.DotnetOrg.Policies/Rules/PR09_TooManyTeamMaintainers.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotnetOrg.Policies.Rules
 
         public override IEnumerable<PolicyViolation> GetViolations(PolicyAnalysisContext context)
         {
-            const int Threshold = 4;
+            const int Threshold = 10;
 
             foreach (var team in context.Org.Teams)
             {


### PR DESCRIPTION
This allows up to 10 admins per repo and up to 10 maintainers per team. In either case, org owners do not contribute to the quota.