### PR TITLE
Fix file name

### DIFF
--- a/doc/PR15.md
+++ b/doc/PR15.md
@@ -1,7 +1,7 @@
 # PR15 Repo must have a Code of Conduct
 
 Public repos need to include a Code of Conduct (CoC), in a file named
-`CODE-OF-CONDUCT.md`.
+`CODE_OF_CONDUCT.md`.
 
 The file shouldn't contain the contents of the CoC text but instead link to the
 latest version so that when we adopt later versions, it takes effect in all


### PR DESCRIPTION
The expected file name is with underscores.

You can see the expected names at https://github.com/dotnet/org-policy/community

Also, when you click Add, you can see:
![image](https://user-images.githubusercontent.com/12971179/78334457-abdd8680-7540-11ea-90df-d657d3f5652e.png)
