### PR TITLE
Add PR17

### DIFF
--- a/doc/PR17.md
+++ b/doc/PR17.md
@@ -1,0 +1,5 @@
+# PR17 Teams should have a sufficient number of maintainers
+
+In order to make sure that a team can be maintained without bottleneck, it needs
+a sufficient number of maintainers. We recommend that each team has at least two
+maintainer, not counting org owners.

--- a/doc/README.md
+++ b/doc/README.md
@@ -18,6 +18,7 @@ Rule            | Severity | Title
 [PR14](PR14.md) | Error    | Repo ownership must be explicit
 [PR15](PR15.md) | Error    | Repo must have a Code of Conduct
 [PR16](PR16.md) | Error    | Repos must link correct Code of Conduct
+[PR17](PR17.md) | Warning  | Teams should have a sufficient number of maintainers
 
 ## Process
 

--- a/src/Microsoft.DotnetOrg.Policies/Rules/PR17_TeamsShouldHaveSufficientNumberOfMaintainers.cs
+++ b/src/Microsoft.DotnetOrg.Policies/Rules/PR17_TeamsShouldHaveSufficientNumberOfMaintainers.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+
+namespace Microsoft.DotnetOrg.Policies.Rules
+{
+    internal sealed class PR17_TeamsShouldHaveSufficientNumberOfMaintainers : PolicyRule
+    {
+        public override PolicyDescriptor Descriptor { get; } = new PolicyDescriptor(
+            "PR17",
+            "Teams should have a sufficient number of maintainers",
+            PolicySeverity.Warning
+        );
+
+        public override void GetViolations(PolicyAnalysisContext context)
+        {
+            const int Threshold = 2;
+            foreach (var team in context.Org.Teams)
+            {
+                if (!team.IsOwnedByMicrosoft())
+                    continue;
+
+                var teamThreshold = Math.Min(Threshold, team.Members.Count);
+                var numberOfMaintainers = team.GetMaintainers().Count();
+
+                if (numberOfMaintainers < teamThreshold)
+                {
+                    context.ReportViolation(
+                        Descriptor,
+                        $"Team '{team.Name}' needs more maintainers",
+                        $@"
+                            The team {team.Markdown()} has {numberOfMaintainers} maintainers. It should have at least {teamThreshold} maintainers.
+                        ",
+                        team: team
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Turns out we currently don't check whether a team has at least 2 maintainers (we only have that rule for repo admins). This will flag the following repos:

* [Analyzer-External](https://github.com/orgs/dotnet/teams/Analyzer-External)
* [aspnet-blazor-eng](https://github.com/orgs/dotnet/teams/aspnet-blazor-eng)
* [bots-high](https://github.com/orgs/dotnet/teams/bots-high)
* [consolidation](https://github.com/orgs/dotnet/teams/consolidation)
* [corefxlab-admin](https://github.com/orgs/dotnet/teams/corefxlab-admin)
* [corefxlab-collaborators](https://github.com/orgs/dotnet/teams/corefxlab-collaborators)
* [csharp-tmLanguage-owners](https://github.com/orgs/dotnet/teams/csharp-tmLanguage-owners)
* [dotnet-cli-admin](https://github.com/orgs/dotnet/teams/dotnet-cli-admin)
* [dotnet-interactive-contributors-team](https://github.com/orgs/dotnet/teams/dotnet-interactive-contributors-team)
* [dotnet-interactive-maintainers-team](https://github.com/orgs/dotnet/teams/dotnet-interactive-maintainers-team)
* [dotnet-llvm-project-admin](https://github.com/orgs/dotnet/teams/dotnet-llvm-project-admin)
* [dotnet-perf-admin](https://github.com/orgs/dotnet/teams/dotnet-perf-admin)
* [dotnet-release-admins](https://github.com/orgs/dotnet/teams/dotnet-release-admins)
* [dotnet-test-templates-admin](https://github.com/orgs/dotnet/teams/dotnet-test-templates-admin)
* [dotnet-try-admin-team](https://github.com/orgs/dotnet/teams/dotnet-try-admin-team)
* [efcore](https://github.com/orgs/dotnet/teams/efcore)
* [Format Owners](https://github.com/orgs/dotnet/teams/format-owners)
* [fsharp](https://github.com/orgs/dotnet/teams/fsharp)
* [fsharp-team-msft](https://github.com/orgs/dotnet/teams/fsharp-team-msft)
* [infer](https://github.com/orgs/dotnet/teams/infer)
* [mbmlbook](https://github.com/orgs/dotnet/teams/mbmlbook)
* [mbmlbook-admin](https://github.com/orgs/dotnet/teams/mbmlbook-admin)
* [MLNET-AutoML](https://github.com/orgs/dotnet/teams/MLNET-AutoML)
* [msbuild-language-service](https://github.com/orgs/dotnet/teams/msbuild-language-service)
* [OPS_WritePermission_Team](https://github.com/orgs/dotnet/teams/OPS_WritePermission_Team)
* [platform-compat-team](https://github.com/orgs/dotnet/teams/platform-compat-team)
* [roslyn-compiler](https://github.com/orgs/dotnet/teams/roslyn-compiler)
* [roslyn-interactive](https://github.com/orgs/dotnet/teams/roslyn-interactive)
* [roslyn-sdk](https://github.com/orgs/dotnet/teams/roslyn-sdk)
* [roslyn-vs-for-mac](https://github.com/orgs/dotnet/teams/roslyn-vs-for-mac)
* [source-build-admins](https://github.com/orgs/dotnet/teams/source-build-admins)
* [source-build-internal](https://github.com/orgs/dotnet/teams/source-build-internal)
* [Spark .NET Admins](https://github.com/orgs/dotnet/teams/spark-net-admins)
* [System.CommandLine](https://github.com/orgs/dotnet/teams/System.CommandLine)
* [TestImpact](https://github.com/orgs/dotnet/teams/TestImpact)
* [try-samples-admin](https://github.com/orgs/dotnet/teams/try-samples-admin)
* [try-samples-contributors](https://github.com/orgs/dotnet/teams/try-samples-contributors)
* [vblangdesign](https://github.com/orgs/dotnet/teams/vblangdesign)
* [vscode-dotnetcore-admins](https://github.com/orgs/dotnet/teams/vscode-dotnetcore-admins)
* [xamarin](https://github.com/orgs/dotnet/teams/xamarin)
* [XHarness](https://github.com/orgs/dotnet/teams/XHarness)

