### PR TITLE
Add PR18: repos shouldn't use deprecated branch names

### DIFF
--- a/doc/PR18.md
+++ b/doc/PR18.md
@@ -1,0 +1,4 @@
+# PR18 Repos shouldn't use deprecated branch names
+
+We've decided to use `main` as the default branch moving forward. This will flag
+repos that use the old terminology.

--- a/src/Microsoft.DotnetOrg.Policies/PolicyRunner.cs
+++ b/src/Microsoft.DotnetOrg.Policies/PolicyRunner.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotnetOrg.Policies
 
         public static Task RunAsync(PolicyAnalysisContext context)
         {
-            var rules = GetRules();
+            var rules = GetRules().Where(r => r.Descriptor.Severity > PolicySeverity.Hidden);
             return RunAsync(context, rules);
         }
 

--- a/src/Microsoft.DotnetOrg.Policies/PolicySeverity.cs
+++ b/src/Microsoft.DotnetOrg.Policies/PolicySeverity.cs
@@ -2,7 +2,8 @@
 {
     public enum PolicySeverity
     {
-        Error,
-        Warning
+        Hidden,
+        Warning,
+        Error
     }
 }

--- a/src/Microsoft.DotnetOrg.Policies/Rules/PR18_ReposShouldNotUseDeprecatedBranchNames.cs
+++ b/src/Microsoft.DotnetOrg.Policies/Rules/PR18_ReposShouldNotUseDeprecatedBranchNames.cs
@@ -1,0 +1,51 @@
+﻿using System;
+
+namespace Microsoft.DotnetOrg.Policies.Rules
+{
+    internal sealed class PR18_ReposShouldNotUseDeprecatedBranchNames : PolicyRule
+    {
+        public override PolicyDescriptor Descriptor { get; } = new PolicyDescriptor(
+            "PR18",
+            "Repos shouldn't use deprecated branch names",
+            PolicySeverity.Hidden
+        );
+
+        public override void GetViolations(PolicyAnalysisContext context)
+        {
+            var deprecatedBranchNames = new (string Deprecated, string Preferred)[]
+            {
+                ("master", "main")
+            };
+
+            foreach (var repo in context.Org.Repos)
+            {
+                if (repo.IsArchived || repo.IsSoftArchived())
+                    continue;
+
+                if (repo.IsFork)
+                    continue;
+
+                if (!repo.IsOwnedByMicrosoft())
+                    continue;
+
+                foreach (var branch in repo.Branches)
+                {
+                    foreach (var (deprecatedName, preferredName) in deprecatedBranchNames)
+                    {
+                        if (branch.Contains(deprecatedName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            context.ReportViolation(
+                                Descriptor,
+                                $"Repo '{repo.Name}' uses deprecated branch name '{branch}'",
+                                $@"
+                                    The repo {repo.Markdown()} contains the branch '{branch}' which contains the deprecated branch name {deprecatedName}. It should use the name '{preferredName}'.
+                                ",
+                                repo: repo
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/policop/Commands/CheckCommand.cs
+++ b/src/policop/Commands/CheckCommand.cs
@@ -90,10 +90,19 @@ namespace Microsoft.DotnetOrg.PolicyCop.Commands
                                 : await GitHubClientFactory.CreateAsync();
 
             var includedRules = PolicyRunner.GetRules().ToList();
-            var existingRules = includedRules.Select(r => r.Descriptor.DiagnosticId).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var existingRules = includedRules.Select(r => r.Descriptor.DiagnosticId)
+                                             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-            if (_includedRuleIds.Count > 0)
+            if (_includedRuleIds.Count == 0)
             {
+                // If we weren't given a list of rules, we only include rules
+                // that aren't hidden.
+                includedRules.RemoveAll(r => r.Descriptor.Severity <= PolicySeverity.Hidden);
+            }
+            else
+            {
+                // Otherwise we include the rules specified, regardless of their
+                // severity.
                 var invalidRuleIds = _includedRuleIds.Where(r => !existingRules.Contains(r));
                 foreach (var invalidRuleId in invalidRuleIds)
                     Console.Error.WriteLine($"warning: policy rule '{invalidRuleId}' doesn't exist");


### PR DESCRIPTION
This adds the ability for rules to be off by default and adds PR18 which validates that a repo doesn't use a deprecated branch name. Since we're still going through the rename, the rule will be off by default, but can be run on the command line like:

```text
$ policop check --org dotnet --rule PR18 --excel
```

Once we're done with most of the branch renames, I suggest we turn the rule on and manage the remaining work on GitHub via the [dotnet/org-policy-violations](https://github.com/dotnet/org-policy-violations/issues) repo.