### PR TITLE
Add PR19 and PR20: ensure default branch and release branches have branch protection rules

### DIFF
--- a/doc/PR19.md
+++ b/doc/PR19.md
@@ -1,0 +1,4 @@
+# PR19 Default branches should have branch protection
+
+The default branches should have branch protection rules, such as preventing
+force pushes and requiring PRs.

--- a/doc/PR20.md
+++ b/doc/PR20.md
@@ -1,0 +1,4 @@
+# PR20 Release branches should have branch protection
+
+Release branches should have branch protection rules, such as preventing force
+pushes and requiring PRs.

--- a/doc/README.md
+++ b/doc/README.md
@@ -20,6 +20,8 @@ Rule            | Severity | Title
 [PR16](PR16.md) | Error    | Repos must link correct Code of Conduct
 [PR17](PR17.md) | Warning  | Teams should have a sufficient number of maintainers
 [PR18](PR18.md) | Warning  | Repos shouldn't use deprecated branch names
+[PR19](PR19.md) | Warning  | Default branches should have branch protection
+[PR20](PR20.md) | Warning  | Release branches should have branch protection
 
 ## Process
 

--- a/src/Microsoft.DotnetOrg.Policies/Rules/PR19_DefaultBranchesShouldBeProtected.cs
+++ b/src/Microsoft.DotnetOrg.Policies/Rules/PR19_DefaultBranchesShouldBeProtected.cs
@@ -1,0 +1,45 @@
+﻿using System.Linq;
+
+namespace Microsoft.DotnetOrg.Policies.Rules
+{
+    internal sealed class PR19_DefaultBranchesShouldBeProtected : PolicyRule
+    {
+        public override PolicyDescriptor Descriptor { get; } = new PolicyDescriptor(
+            "PR19",
+            "Default branches should have branch protection",
+            PolicySeverity.Warning
+        );
+
+        public override void GetViolations(PolicyAnalysisContext context)
+        {
+            foreach (var repo in context.Org.Repos)
+            {
+                if (repo.IsFork || repo.IsTemporaryForkForSecurityAdvisory())
+                    continue;
+
+                if (repo.IsArchivedOrSoftArchived())
+                    continue;
+
+                if (!repo.IsOwnedByMicrosoft())
+                    continue;
+
+                // Let's ignore uninitialized repos
+                if (repo.DefaultBranch is null)
+                    continue;
+
+                if (!repo.DefaultBranch.Rules.Any())
+                {
+                    context.ReportViolation(
+                        Descriptor,
+                        $"The default branch '{repo.DefaultBranch.Name}' in '{repo.Name}' has no branch protection",
+                        $@"
+                            The default branch {repo.DefaultBranch.Markdown()} in repo {repo.Markdown()} should have branch protection rules, such as preventing force pushes and requiring PRs.
+                        ",
+                        repo: repo,
+                        branch: repo.DefaultBranch
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotnetOrg.Policies/Rules/PR20_ReleaseBranchesShouldBeProtected.cs
+++ b/src/Microsoft.DotnetOrg.Policies/Rules/PR20_ReleaseBranchesShouldBeProtected.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+
+namespace Microsoft.DotnetOrg.Policies.Rules
+{
+    internal sealed class PR20_ReleaseBranchesShouldBeProtected : PolicyRule
+    {
+        public override PolicyDescriptor Descriptor { get; } = new PolicyDescriptor(
+            "PR20",
+            "Release branches should have branch protection",
+            PolicySeverity.Warning
+        );
+
+        public override void GetViolations(PolicyAnalysisContext context)
+        {
+            foreach (var repo in context.Org.Repos)
+            {
+                if (repo.IsFork || repo.IsTemporaryForkForSecurityAdvisory())
+                    continue;
+
+                if (repo.IsArchivedOrSoftArchived())
+                    continue;
+
+                if (!repo.IsOwnedByMicrosoft())
+                    continue;
+
+                var unprotectedReleaseBranches = repo.Branches.Where(b => b.Name.StartsWith("release", StringComparison.OrdinalIgnoreCase))
+                                                              .Where(b => !b.Rules.Any());
+
+                foreach (var branch in unprotectedReleaseBranches)
+                {
+                    context.ReportViolation(
+                        Descriptor,
+                        $"The release branch '{branch.Name}' in '{repo.Name}' has no branch protection",
+                        $@"
+                            The branch {branch.Markdown()} in repo {repo.Markdown()} appears to be a release branch and should have branch protection rules, such as preventing force pushes and requiring PRs.
+                        ",
+                        repo: repo,
+                        branch: branch
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
These rules check that the default branch (PR19) and all release branches (PR20) have branch protection rules.

Sadly, the GitHub API doesn't include the setting to indicate whether force pushes are disabled, which is probably the minimum we want to prescribe. Right now, the tool just flags branches in repos that don't have any matching rules.

<details>
<summary>Flagged Repos</summary>

| repo                             | branch                         | rule |
|----------------------------------|--------------------------------|------|
| announcements                    | main                           | PR19 |
| api-catalog-infra                | main                           | PR19 |
| api-catalog-infra                | release/5.0                    | PR20 |
| api-catalog-infra                | release/6.0-preview2           | PR20 |
| api-catalog-infra                | release/6.0-preview3           | PR20 |
| apireviews                       | main                           | PR19 |
| apireviews-microsoft             | main                           | PR19 |
| arcade                           | release/5.0                    | PR20 |
| arcade-extensions                | main                           | PR19 |
| arcade-pool-provider             | main                           | PR19 |
| arcade-validation                | main                           | PR19 |
| arcade-validation                | release/3.x                    | PR20 |
| arcade-validation                | release/5.0                    | PR20 |
| AspNetApiDocs.cs-cz              | live                           | PR19 |
| AspNetApiDocs.de-de              | live                           | PR19 |
| AspNetApiDocs.es-es              | live                           | PR19 |
| AspNetApiDocs.fr-fr              | live                           | PR19 |
| AspNetApiDocs.it-it              | live                           | PR19 |
| AspNetApiDocs.ja-jp              | live                           | PR19 |
| AspNetApiDocs.ko-kr              | live                           | PR19 |
| AspNetApiDocs.pl-pl              | live                           | PR19 |
| AspNetApiDocs.pt-br              | live                           | PR19 |
| AspNetApiDocs.ru-ru              | live                           | PR19 |
| AspNetApiDocs.tr-tr              | live                           | PR19 |
| AspNetApiDocs.zh-cn              | live                           | PR19 |
| AspNetApiDocs.zh-tw              | live                           | PR19 |
| blazor-fluentui                  | main                           | PR19 |
| brand                            | main                           | PR19 |
| BuildPerformanceTestAssets       | main                           | PR19 |
| CliCommandLineParser             | main                           | PR19 |
| CliCommandLineParser             | release/2.1.3xx                | PR20 |
| CliCommandLineParser             | release/2.1.3xx-src            | PR20 |
| cli-lab                          | main                           | PR19 |
| cli-perf-data                    | main                           | PR19 |
| codeformatter                    | main                           | PR19 |
| Comet                            | dev                            | PR19 |
| core-eng                         | main                           | PR19 |
| core-private                     | main                           | PR19 |
| crank                            | main                           | PR19 |
| csharplang                       | main                           | PR19 |
| csharplang.cs-cz                 | main                           | PR19 |
| csharplang.de-de                 | main                           | PR19 |
| csharplang.es-es                 | main                           | PR19 |
| csharplang.fr-fr                 | main                           | PR19 |
| csharplang.it-it                 | main                           | PR19 |
| csharplang.ja-jp                 | main                           | PR19 |
| csharplang.ko-kr                 | main                           | PR19 |
| csharplang.pl-pl                 | main                           | PR19 |
| csharplang.pt-br                 | main                           | PR19 |
| csharplang.ru-ru                 | main                           | PR19 |
| csharplang.tr-tr                 | main                           | PR19 |
| csharplang.zh-cn                 | main                           | PR19 |
| csharplang.zh-tw                 | main                           | PR19 |
| cssparser                        | main                           | PR19 |
| datalab                          | main                           | PR19 |
| deployment-tools                 | main                           | PR19 |
| deployment-tools                 | release/5.0                    | PR20 |
| deployment-tools                 | release/5.0-rc2                | PR20 |
| designs                          | main                           | PR19 |
| designs-microsoft                | main                           | PR19 |
| docker-tools                     | main                           | PR19 |
| docs-desktop.cs-cz               | main                           | PR19 |
| docs-desktop.de-de               | main                           | PR19 |
| docs-desktop.es-es               | main                           | PR19 |
| docs-desktop.fr-fr               | main                           | PR19 |
| docs-desktop.it-it               | main                           | PR19 |
| docs-desktop.ja-jp               | main                           | PR19 |
| docs-desktop.ko-kr               | main                           | PR19 |
| docs-desktop.pl-pl               | main                           | PR19 |
| docs-desktop.pt-br               | main                           | PR19 |
| docs-desktop.ru-ru               | main                           | PR19 |
| docs-desktop.tr-tr               | main                           | PR19 |
| docs-desktop.zh-cn               | main                           | PR19 |
| docs-desktop.zh-tw               | main                           | PR19 |
| dotnet-api-docs                  | release-msbuild                | PR20 |
| dotnet-api-docs.cs-cz            | live                           | PR19 |
| dotnet-api-docs.de-de            | live                           | PR19 |
| dotnet-api-docs.es-es            | live                           | PR19 |
| dotnet-api-docs.fr-fr            | live                           | PR19 |
| dotnet-api-docs.it-it            | live                           | PR19 |
| dotnet-api-docs.ja-jp            | live                           | PR19 |
| dotnet-api-docs.ko-kr            | live                           | PR19 |
| dotnet-api-docs.pl-pl            | live                           | PR19 |
| dotnet-api-docs.pt-br            | live                           | PR19 |
| dotnet-api-docs.ru-ru            | live                           | PR19 |
| dotnet-api-docs.tr-tr            | live                           | PR19 |
| dotnet-api-docs.zh-cn            | live                           | PR19 |
| dotnet-api-docs.zh-tw            | live                           | PR19 |
| dotnet-buildtools-prereqs-docker | main                           | PR19 |
| ef6                              | release-6.1.3-tools-dev15      | PR20 |
| ef6                              | release-6.1.3-tools-dev15-test | PR20 |
| ef6                              | release-6.1.3-tools-update-2   | PR20 |
| ef6tools                         | main                           | PR19 |
| EntityFramework.ApiDocs.cs-cz    | live                           | PR19 |
| EntityFramework.ApiDocs.de-de    | live                           | PR19 |
| EntityFramework.ApiDocs.es-es    | live                           | PR19 |
| EntityFramework.ApiDocs.fr-fr    | live                           | PR19 |
| EntityFramework.ApiDocs.it-it    | live                           | PR19 |
| EntityFramework.ApiDocs.ja-jp    | live                           | PR19 |
| EntityFramework.ApiDocs.ko-kr    | live                           | PR19 |
| EntityFramework.ApiDocs.pl-pl    | live                           | PR19 |
| EntityFramework.ApiDocs.pt-br    | live                           | PR19 |
| EntityFramework.ApiDocs.ru-ru    | live                           | PR19 |
| EntityFramework.ApiDocs.tr-tr    | live                           | PR19 |
| EntityFramework.ApiDocs.zh-cn    | live                           | PR19 |
| EntityFramework.ApiDocs.zh-tw    | live                           | PR19 |
| EntityFramework.Docs             | main                           | PR19 |
| EntityFramework.Docs.ru-ru       | live                           | PR19 |
| fsharp-api-docs                  | main                           | PR19 |
| fuzzing                          | main                           | PR19 |
| GraphicsControls                 | main                           | PR19 |
| hotreload-utils                  | main                           | PR19 |
| interactive                      | release/hotfix                 | PR20 |
| iot-api-docs                     | main                           | PR19 |
| issue-labeler                    | main                           | PR19 |
| JavaApiDocs                      | main                           | PR19 |
| llilc                            | main                           | PR19 |
| machinelearning-modelbuilder     | main                           | PR19 |
| machinelearning-samples          | main                           | PR19 |
| machinelearning-samples          | release/1.1                    | PR20 |
| machinelearning-samples          | release/1.2                    | PR20 |
| machinelearning-samples          | release/1.3.1                  | PR20 |
| machinelearning-testdata         | main                           | PR19 |
| manufacturingtelemetry           | main                           | PR19 |
| mbmlbook                         | main                           | PR19 |
| metadata-tools                   | main                           | PR19 |
| Microsoft.Maui.Graphics          | release/nuget                  | PR20 |
| ml-api-docs.cs-cz                | live                           | PR19 |
| ml-api-docs.de-de                | live                           | PR19 |
| ml-api-docs.es-es                | live                           | PR19 |
| ml-api-docs.fr-fr                | live                           | PR19 |
| ml-api-docs.it-it                | live                           | PR19 |
| ml-api-docs.ja-jp                | live                           | PR19 |
| ml-api-docs.ko-kr                | live                           | PR19 |
| ml-api-docs.pl-pl                | live                           | PR19 |
| ml-api-docs.pt-br                | live                           | PR19 |
| ml-api-docs.ru-ru                | live                           | PR19 |
| ml-api-docs.tr-tr                | live                           | PR19 |
| ml-api-docs.zh-cn                | live                           | PR19 |
| ml-api-docs.zh-tw                | live                           | PR19 |
| mono-policy-violations           | main                           | PR19 |
| net6-mobile-samples              | main                           | PR19 |
| new-repo                         | main                           | PR19 |
| nuget-policy-violations          | main                           | PR19 |
| org-policy                       | main                           | PR19 |
| orleans-docs                     | main                           | PR19 |
| performance                      | main                           | PR19 |
| performance                      | release/3.1.1xx                | PR20 |
| performance                      | release/3.1.2xx                | PR20 |
| performance                      | release/3.1.3xx                | PR20 |
| performance                      | release/3.1.4xx                | PR20 |
| performance                      | release/5.0.1xx                | PR20 |
| performance                      | release/5.0.2xx                | PR20 |
| performance                      | release/5.0-runtime            | PR20 |
| pgo                              | main                           | PR19 |
| ProjFileTools                    | main                           | PR19 |
| release                          | main                           | PR19 |
| roslyn-analyzers                 | release/5.0.1xx                | PR20 |
| roslyn-analyzers                 | release/5.0.2xx                | PR20 |
| roslyn-analyzers                 | release/6.0.1xx                | PR20 |
| roslyn-analyzers                 | release/6.0.1xx-preview1       | PR20 |
| roslyn-analyzers                 | release/6.0.1xx-preview2       | PR20 |
| roslyn-analyzers                 | release/6.0.1xx-preview3       | PR20 |
| roslyn-analyzers                 | release/6.0.1xx-preview4       | PR20 |
| roslyn-debug                     | main                           | PR19 |
| roslyn-tools                     | main                           | PR19 |
| Scaffolding                      | main                           | PR19 |
| Scaffolding                      | release/3.1                    | PR20 |
| Scaffolding                      | release/5.0                    | PR20 |
| Scaffolding                      | release/5.0-preview3           | PR20 |
| Scaffolding                      | release/5.0-preview4           | PR20 |
| Scaffolding                      | release/5.0-preview5           | PR20 |
| Scaffolding                      | release/5.0-preview6           | PR20 |
| Scaffolding                      | release/5.0-preview7           | PR20 |
| Scaffolding                      | release/5.0-preview8           | PR20 |
| Scaffolding                      | release/5.0-rc2                | PR20 |
| Scaffolding                      | release/6.0-preview1           | PR20 |
| Scaffolding                      | release/6.0-preview2           | PR20 |
| Scaffolding                      | release/6.0-preview3           | PR20 |
| source-indexer                   | main                           | PR19 |
| sourcelink                       | main                           | PR19 |
| sourcelink                       | release/1.0.0                  | PR20 |
| symreader-converter              | main                           | PR19 |
| symreader-portable               | main                           | PR19 |
| symstore                         | main                           | PR19 |
| SyndicationFeedReaderWriter      | main                           | PR19 |
| templates                        | main                           | PR19 |
| tye                              | main                           | PR19 |
| uwp-setup                        | main                           | PR19 |
| vblang                           | main                           | PR19 |
| vblang.cs-cz                     | main                           | PR19 |
| vblang.de-de                     | main                           | PR19 |
| vblang.es-es                     | main                           | PR19 |
| vblang.fr-fr                     | main                           | PR19 |
| vblang.it-it                     | main                           | PR19 |
| vblang.ja-jp                     | main                           | PR19 |
| vblang.ko-kr                     | main                           | PR19 |
| vblang.pl-pl                     | main                           | PR19 |
| vblang.pt-br                     | main                           | PR19 |
| vblang.ru-ru                     | main                           | PR19 |
| vblang.tr-tr                     | main                           | PR19 |
| vblang.zh-cn                     | main                           | PR19 |
| vblang.zh-tw                     | main                           | PR19 |
| versions                         | main                           | PR19 |
| wcf                              | release/3.2                    | PR20 |
| websdk                           | release/2.1                    | PR20 |
| websdk                           | release/2.1.2xx                | PR20 |
| websdk                           | release/2.1.5xx                | PR20 |
| websdk                           | release/2.2.2xx                | PR20 |
| websdk                           | release/3.0.1xx                | PR20 |
| websdk                           | release/3.1.1xx                | PR20 |
| websdk                           | release/3.1.2xx                | PR20 |
| websdk                           | release/3.1.3xx                | PR20 |
| websdk                           | release/3.1.4xx                | PR20 |
| website-getdotnet                | main                           | PR19 |
| windowsdesktop                   | main                           | PR19 |
| windowsdesktop                   | release/5.0                    | PR20 |
| windowsdesktop                   | release/6.0-preview1           | PR20 |
| windowsdesktop                   | release/6.0-preview2           | PR20 |
| windowsdesktop                   | release/6.0-preview3           | PR20 |
| windowsdesktop                   | release/6.0-preview4           | PR20 |
| windows-desktop                  | main                           | PR19 |
| winforms                         | release/6.0-preview1           | PR20 |
| winforms                         | release/6.0-preview2           | PR20 |
| winforms                         | release/6.0-preview3           | PR20 |
| winforms                         | release/6.0-preview4           | PR20 |
| xamarin                          | main                           | PR19 |
| xdt                              | main                           | PR19 |
| xdt                              | release/3.0                    | PR20 |
| xdt                              | release/3.1                    | PR20 |
| xliff-tasks                      | main                           | PR19 |

</summary>